### PR TITLE
Updated FollowerCell set(); Created downloadImage() in GUAvatarImageView

### DIFF
--- a/GithubUsers/GithubUsers/Custom Views/Cells/FollowerCell.swift
+++ b/GithubUsers/GithubUsers/Custom Views/Cells/FollowerCell.swift
@@ -26,6 +26,7 @@ class FollowerCell: UICollectionViewCell {
     
     func set(follower: Follower) {
         usernameLabel.text = follower.login
+        avatarImageView.downloadImage(from: follower.avatarUrl)
     }
     
     private func configure() {

--- a/GithubUsers/GithubUsers/Custom Views/GUAvatarImageView.swift
+++ b/GithubUsers/GithubUsers/Custom Views/GUAvatarImageView.swift
@@ -28,4 +28,24 @@ class GUAvatarImageView: UIImageView {
         clipsToBounds = true            // clips avatar UIImage to bounds of UIImageView so it also conforms to rounded edges
         image = placeholderImage        // sets the default image view in case of no avatar to placeholder image
     }
+    
+    func downloadImage(from urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        
+        let task = URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+            guard let self = self else { return }
+            
+            if error != nil { return }
+            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else { return }
+            guard let data = data else { return }
+            
+            guard let image = UIImage(data: data) else { return }
+            
+            DispatchQueue.main.async {
+                self.image = image
+            }
+        }
+        
+        task.resume()
+    }
 }


### PR DESCRIPTION
When a FollowerCell is created and it calls its set function to display the followers login as the usernameLabel text, it will now also download the avatar image for the avatarImageView. In GUAvatarImageView there is a new function called downloadImage() that takes a urlString as a parameter passed from follower.avatarUrl to then start a network request data task to get the image and display it on the UI.