### PR TITLE
Added Button Functionality

### DIFF
--- a/GithubUsers/GithubUsers/Custom Views/ViewControllers/ItemInfoVCs/GUFollowerItemVC.swift
+++ b/GithubUsers/GithubUsers/Custom Views/ViewControllers/ItemInfoVCs/GUFollowerItemVC.swift
@@ -21,4 +21,8 @@ class GUFollowerItemVC: GUItemInfoVC {
         itemInfoViewTwo.set(itemInfoType: .following, with: user.following)
         actionButton.set(backgroundColor: .systemGreen, title: "Get Followers")
     }
+    
+    override func actionButtonTapped() {
+        delegate.didTapGetFollowers(for: user)
+    }
 }

--- a/GithubUsers/GithubUsers/Custom Views/ViewControllers/ItemInfoVCs/GUItemInfoVC.swift
+++ b/GithubUsers/GithubUsers/Custom Views/ViewControllers/ItemInfoVCs/GUItemInfoVC.swift
@@ -16,6 +16,7 @@ class GUItemInfoVC: UIViewController {
     let actionButton = GUButton()
     
     var user: User!
+    weak var delegate: UserInfoVCDelegate!
     
     init(user: User) {
         super.init(nibName: nil, bundle: nil)
@@ -32,6 +33,7 @@ class GUItemInfoVC: UIViewController {
         // Do any additional setup after loading the view.
         configureBackgroundView()
         configureStackView()
+        configureActionButton()
         layoutUI()
     }
     
@@ -47,6 +49,13 @@ class GUItemInfoVC: UIViewController {
         stackView.addArrangedSubview(itemInfoViewOne)
         stackView.addArrangedSubview(itemInfoViewTwo)
     }
+    
+    private func configureActionButton() {
+        actionButton.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
+    }
+    
+    // Will implement this in subclasses
+    @objc func actionButtonTapped() {}
 
     private func layoutUI() {
         view.addSubview(stackView)

--- a/GithubUsers/GithubUsers/Custom Views/ViewControllers/ItemInfoVCs/GURepoItemVC.swift
+++ b/GithubUsers/GithubUsers/Custom Views/ViewControllers/ItemInfoVCs/GURepoItemVC.swift
@@ -21,4 +21,8 @@ class GURepoItemVC: GUItemInfoVC {
         itemInfoViewTwo.set(itemInfoType: .gists, with: user.publicGists)
         actionButton.set(backgroundColor: .systemPurple, title: "Github Profile")
     }
+    
+    override func actionButtonTapped() {
+        delegate.didTapGitHubProfile(for: user)
+    }
 }

--- a/GithubUsers/GithubUsers/Extensions/UIViewController+Ext.swift
+++ b/GithubUsers/GithubUsers/Extensions/UIViewController+Ext.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SafariServices
 
 fileprivate var containerView: UIView!
 
@@ -19,6 +20,12 @@ extension UIViewController {
             
             self.present(alertVC, animated: true)
         }
+    }
+    
+    func presentSafariVC(with url: URL) {
+        let safariVC = SFSafariViewController(url: url)
+        safariVC.preferredControlTintColor = .systemGreen
+        present(safariVC, animated: true)
     }
     
     func showLoadingView() {

--- a/GithubUsers/GithubUsers/Screens/FollowersListVC.swift
+++ b/GithubUsers/GithubUsers/Screens/FollowersListVC.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol FollowersListVCDelegate: AnyObject {
+    func didRequestFollowers(for username: String)
+}
+
 class FollowersListVC: UIViewController {
     
     enum Section { case main }
@@ -133,6 +137,7 @@ extension FollowersListVC: UICollectionViewDelegate {
         
         let destVC = UserInfoVC()
         destVC.username = follower.login
+        destVC.delegate = self
         
         let navController = UINavigationController(rootViewController: destVC)
         present(navController, animated: true)
@@ -152,4 +157,22 @@ extension FollowersListVC: UISearchResultsUpdating, UISearchBarDelegate {
         isSearching = false
         updateData(on: followers)
     }
+}
+
+extension FollowersListVC: FollowersListVCDelegate {
+    
+    func didRequestFollowers(for username: String) {
+        // Reset the state of FollowersListVC screen
+        self.username = username
+        title = username
+        page = 1
+        
+        followers.removeAll()
+        filteredFollowers.removeAll()
+        collectionView.setContentOffset(.zero, animated: true)
+        
+        // Set to new user
+        getFollowers(username: username, page: page)
+    }
+    
 }

--- a/GithubUsers/GithubUsers/Screens/UserInfoVC.swift
+++ b/GithubUsers/GithubUsers/Screens/UserInfoVC.swift
@@ -7,6 +7,11 @@
 
 import UIKit
 
+protocol UserInfoVCDelegate: AnyObject {
+    func didTapGitHubProfile(for user: User)
+    func didTapGetFollowers(for user: User)
+}
+
 class UserInfoVC: UIViewController {
     
     let headerView = UIView()
@@ -16,6 +21,7 @@ class UserInfoVC: UIViewController {
     var itemViews: [UIView] = []
     
     var username: String!
+    weak var delegate: FollowersListVCDelegate!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -31,6 +37,19 @@ class UserInfoVC: UIViewController {
         view.backgroundColor = .systemBackground
         let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissVC))
         navigationItem.rightBarButtonItem = doneButton
+    }
+    
+    func configureUIElements(with user: User) {
+        let repoItemVC = GURepoItemVC(user: user)
+        repoItemVC.delegate = self
+        
+        let followerItemVC = GUFollowerItemVC(user: user)
+        followerItemVC.delegate = self
+        
+        self.add(childVC: GUUserInfoHeaderVC(user: user), to: self.headerView)
+        self.add(childVC: repoItemVC, to: self.itemViewOne)
+        self.add(childVC: followerItemVC, to: self.itemViewTwo)
+        self.dateLabel.text = "GitHub Since \(user.createdAt.convertToDisplayFormat())"
     }
     
     func layoutUI() {
@@ -69,12 +88,7 @@ class UserInfoVC: UIViewController {
             
             switch result {
             case .success(let user):
-                DispatchQueue.main.async {
-                    self.add(childVC: GUUserInfoHeaderVC(user: user), to: self.headerView)
-                    self.add(childVC: GURepoItemVC(user: user), to: self.itemViewOne)
-                    self.add(childVC: GUFollowerItemVC(user: user), to: self.itemViewTwo)
-                    self.dateLabel.text = "GitHub Since \(user.createdAt.convertToDisplayFormat())"
-                }
+                DispatchQueue.main.async { self.configureUIElements(with: user) }
             case .failure(let error):
                 self.presentGUAlertOnMainThread(alertTitle: "Something Went Wrong", message: error.rawValue, buttonTitle: "Ok")
             }
@@ -92,4 +106,27 @@ class UserInfoVC: UIViewController {
     @objc func dismissVC() {
         dismiss(animated: true)
     }
+}
+
+extension UserInfoVC: UserInfoVCDelegate {
+    func didTapGitHubProfile(for user: User) {
+        // Show Safari View Controller
+        guard let url = URL(string: user.htmlUrl) else {
+            presentGUAlertOnMainThread(alertTitle: "Invalid URL", message: "The url attached to this user is invalid", buttonTitle: "Ok")
+            return
+        }
+        
+        presentSafariVC(with: url)
+    }
+    
+    func didTapGetFollowers(for user: User) {
+        guard user.followers != 0 else { presentGUAlertOnMainThread(alertTitle: "No followers", message: "This user has no followers", buttonTitle: "So sad")
+            return
+        }
+        // Tell FollowersListVC screen the new user
+        delegate.didRequestFollowers(for: user.login)
+        dismissVC()
+    }
+    
+    
 }


### PR DESCRIPTION
Setup delegate protocols in UserInfoVC and FollowersListVC. Added delegate property in GUItemInfoVC parent class along with a target to configure the action button, but left declaration and setting of the delegate and action button functionality to the subclasses GUFollowerItemVC and GURepoItemVC. The GitHub Profile button is pressed the GURepoItemVC will call didTapGitHubProfile on the delegate and pass the user. This will then prompt the delegate in UserInfoVC to call present the safari VC that was implemented in UIViewController+Ext. When the Get Followers button is pressed the GUFollowerItemVC will call didTapGetFollowers on the delegate and pass the user. This will then prompt the delegate in UserInfoVC to call the delegate property it has, which references followersListVC and call didRequestFollowers passing the username of the user to then reset the state of the FollowersListVC screen and then set the new user by calling getFollowers() again. Shortly afterwards it will dismiss the old VC to present the new followers list.