### PR TITLE
Created Custom Favorite Cell; Set up TableView in FavoritesListVC

### DIFF
--- a/GithubUsers/GithubUsers.xcodeproj/project.pbxproj
+++ b/GithubUsers/GithubUsers.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		87021AF02B7C066C00D13F19 /* GUTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87021AEF2B7C066C00D13F19 /* GUTextField.swift */; };
 		87021AF22B7C196300D13F19 /* FollowersListVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87021AF12B7C196300D13F19 /* FollowersListVC.swift */; };
 		871DA8AA2B9F99EB006EB8AB /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871DA8A92B9F99EB006EB8AB /* PersistenceManager.swift */; };
+		871DA8AC2B9FA57D006EB8AB /* FavoriteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871DA8AB2B9FA57D006EB8AB /* FavoriteCell.swift */; };
 		8726626A2B8E6BB100E841D9 /* GUError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872662692B8E6BB100E841D9 /* GUError.swift */; };
 		8726626D2B8E6E7700E841D9 /* FollowerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8726626C2B8E6E7700E841D9 /* FollowerCell.swift */; };
 		8726626F2B8E6ED100E841D9 /* GUAvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8726626E2B8E6ED100E841D9 /* GUAvatarImageView.swift */; };
@@ -47,6 +48,7 @@
 		87021AEF2B7C066C00D13F19 /* GUTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUTextField.swift; sourceTree = "<group>"; };
 		87021AF12B7C196300D13F19 /* FollowersListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowersListVC.swift; sourceTree = "<group>"; };
 		871DA8A92B9F99EB006EB8AB /* PersistenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
+		871DA8AB2B9FA57D006EB8AB /* FavoriteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCell.swift; sourceTree = "<group>"; };
 		872662692B8E6BB100E841D9 /* GUError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUError.swift; sourceTree = "<group>"; };
 		8726626C2B8E6E7700E841D9 /* FollowerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowerCell.swift; sourceTree = "<group>"; };
 		8726626E2B8E6ED100E841D9 /* GUAvatarImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUAvatarImageView.swift; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				8726626C2B8E6E7700E841D9 /* FollowerCell.swift */,
+				871DA8AB2B9FA57D006EB8AB /* FavoriteCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -351,6 +354,7 @@
 				87D2C79A2B97BC7800A43B96 /* GUUserInfoHeaderVC.swift in Sources */,
 				87D341822B7E951A00BF6E4B /* GUTitleLabel.swift in Sources */,
 				871DA8AA2B9F99EB006EB8AB /* PersistenceManager.swift in Sources */,
+				871DA8AC2B9FA57D006EB8AB /* FavoriteCell.swift in Sources */,
 				8726627B2B96792C00E841D9 /* UserInfoVC.swift in Sources */,
 				8764F4AB2B7EB02800B05C40 /* Follower.swift in Sources */,
 				8764F4A02B7E969200B05C40 /* GUAlertVC.swift in Sources */,

--- a/GithubUsers/GithubUsers/Custom Views/Cells/FavoriteCell.swift
+++ b/GithubUsers/GithubUsers/Custom Views/Cells/FavoriteCell.swift
@@ -1,0 +1,51 @@
+//
+//  FavoriteCell.swift
+//  GithubUsers
+//
+//  Created by Marco Capraro on 3/11/24.
+//
+
+import UIKit
+
+class FavoriteCell: UITableViewCell {
+    static let reuseID = "FavoriteCell"
+    
+    let avatarImageView = GUAvatarImageView(frame: .zero)
+    let usernameLabel = GUTitleLabel(textAlignment: .left, fontSize: 26)
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        // Custom Configuration
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func set(favorite: Follower) {
+        usernameLabel.text = favorite.login
+        avatarImageView.setImage(from: favorite.avatarUrl)
+    }
+    
+    private func configure() {
+        addSubview(avatarImageView)
+        addSubview(usernameLabel)
+        
+        accessoryType = .disclosureIndicator
+        let padding: CGFloat = 12
+        
+        NSLayoutConstraint.activate([
+            avatarImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            avatarImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: padding),
+            avatarImageView.widthAnchor.constraint(equalToConstant: 60),
+            avatarImageView.heightAnchor.constraint(equalToConstant: 60),
+            
+            usernameLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            usernameLabel.leadingAnchor.constraint(equalTo: avatarImageView.trailingAnchor, constant: 24),
+            usernameLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -padding),
+            usernameLabel.heightAnchor.constraint(equalToConstant: 40)
+        ])
+    }
+}

--- a/GithubUsers/GithubUsers/Screens/FavoritesListVC.swift
+++ b/GithubUsers/GithubUsers/Screens/FavoritesListVC.swift
@@ -8,22 +8,104 @@
 import UIKit
 
 class FavoritesListVC: UIViewController {
+    
+    let tableView = UITableView()
+    var favorites: [Follower] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
+        configureViewController()
+        configureTableView()
+    }
+    
+    // Ensure that mid-session favorites can be refreshed
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        getFavorites()
+    }
+    
+    func configureViewController() {
         view.backgroundColor = .systemBackground
+        title = "Favorites"
+        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+    
+    func configureTableView() {
+        view.addSubview(tableView)
+        tableView.frame = view.bounds
+        tableView.rowHeight = 80
+        tableView.delegate = self
+        tableView.dataSource = self
         
-        PersistenceManager.retrieveFavorites { result in
+        tableView.register(FavoriteCell.self, forCellReuseIdentifier: FavoriteCell.reuseID)
+    }
+    
+    func getFavorites() {
+        // Get favorites list from UserDefaults via PersistenceManager
+        PersistenceManager.retrieveFavorites { [weak self] result in
+            guard let self = self else { return  }
             switch result {
             case.success(let favorites):
-                print(favorites)
+                // Populate favorites array or show empty state
+                if(favorites.isEmpty) {
+                    showEmptyStateView(with: "No Favorites?\nAdd one on the follower screen", in: self.view)
+                } else {
+                    self.favorites = favorites
+                    DispatchQueue.main.async {
+                        self.tableView.reloadData()
+                        // Edge case, in case empty state is put ontop of tableView (prevents)
+                        self.view.bringSubviewToFront(self.tableView)
+                    }
+                }
             case .failure(let error):
-                break
+                self.presentGUAlertOnMainThread(alertTitle: "Something went wrong", message: error.rawValue, buttonTitle: "Ok")
                 
             }
         }
     }
 
+}
+
+extension FavoritesListVC: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return favorites.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: FavoriteCell.reuseID) as! FavoriteCell
+        let favorite = favorites[indexPath.row]
+        cell.set(favorite: favorite)
+        
+        return cell
+    }
+    
+    // When selecting a favorite user, present their followers
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let favorite = favorites[indexPath.row]
+        let destVC = FollowersListVC()
+        destVC.username = favorite.login
+        destVC.title = favorite.login
+        
+        navigationController?.pushViewController(destVC, animated: true)
+    }
+    
+    // Setup swipe to delete favorite user
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        guard editingStyle == .delete else { return }
+        let favorite = favorites[indexPath.row]
+        favorites.remove(at: indexPath.row)
+        
+        tableView.deleteRows(at: [indexPath], with: .left)
+        
+        PersistenceManager.updateWith(favorite: favorite, actionType: .remove) { [weak self] error in
+            guard let self = self else { return }
+            guard let error = error else { return }
+            
+            self.presentGUAlertOnMainThread(alertTitle: "Unable to remove", message: error.rawValue, buttonTitle: "Ok")
+        }
+    }
+    
+    
 }


### PR DESCRIPTION
FavoritesListVC now contains a UITableView() that gets populated with the users list of favorite followers. Whenever the screen will appear, the table view will refresh with the current list of favorite users. If the user has no favorites, an empty state will be shown, otherwise it will reload the table view with the new favorites. The user can delete favorites using the swipe gesture on this screen, which will not only remove it from the view, but also from UserDefaults via the PersistenceManager. When a favorite is selected it will then create a new FollowersListVC screen and present it with the followers list of that favorite user. The favorites table view cells will display the username and avatar image of each favorite.